### PR TITLE
FIX "because change changed" error

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -74,7 +74,7 @@ exports.attach = function () {
   // Or, ignore: function(fileName) { return !watchFilter(fileName) }
   chokidar
     .watch(this.watchDirectory, opts)
-    .on('all', function(f, stat) {
+    .on('all', function(stat, f) {
       monitor.emit('watch:restart', { file: f, stat: stat });
       monitor.restart();
     });


### PR DESCRIPTION
The parameters are in the wrong order so that "stat-property" contains the file name and the "file-property" contains the stat